### PR TITLE
feat: Add disabled class to CSS to prevent double-clicking on a square

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,8 +31,7 @@ upperLeftBox.addEventListener('click',function() {
     preventChangingTokens(upperLeftBox); 
     changeTurn();
     keepTrackOfPositions(0);
-    //index position 0
-    // bring this info into keepTrack
+   
 });
 upperMiddleBox.addEventListener('click', function() {
     updateToken(upperMiddleBox);
@@ -112,8 +111,10 @@ function updateToken(box) {
 function preventChangingTokens(box){ 
     if (box.innerText === player1.token) {
         box.classList.add('disabled')
+        box.disabled = true;
     } else if (box.innerText === player2.token) {
         box.classList.add('disabled')
+        box.disabled = true;
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -82,3 +82,7 @@ body {
 .remove-bottom-margin {
     border-bottom: 5px solid transparent;
 }
+
+.disabled { 
+    pointer-events: none;
+}


### PR DESCRIPTION
This branch adds a disabled class to the CSS file to prevent double-clicking on a square that already has a player token in it. 

