### PR TITLE
fix: Refactor CSS to fix styling on the wins count trackers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,13 +40,20 @@ body {
 }
 
 .wins-tracker-left,
-.wins-tracker-right,
+.wins-tracker-right {
+    color: gray;
+    font-size: 40px;
+    margin: 0;
+    padding-top: 30%;
+    text-align: center;
+}
+
 .wins-counter-right,
 .wins-counter-left {
     color: gray;
     font-size: 40px;
     margin: 0;
-    padding-top: 30%;
+    padding-top: 10%;
     text-align: center;
 }
 


### PR DESCRIPTION
# Description

The tracker for the wins count is now styled so it is closer to the player name above it. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

User app tested. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings